### PR TITLE
Add acs cli to splunk brewtap

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ brew upgrade <package-name>
 |:------------ |:-------------------- |
 | scloud       | The Splunk Cloud CLI |
 | qbec       | A CLI tool that allows you to create Kubernetes objects on multiple Kubernetes clusters or namespaces configured correctly for the target environment in question |
-
+| acs       | Splunk Admin Config Service CLI |
 

--- a/acs.rb
+++ b/acs.rb
@@ -1,0 +1,24 @@
+class Acs < Formula
+
+  desc "Splunk Admin Config Service CLI"
+  homepage "https://github.com/splunk/acs-cli"
+  version "2.0.0-beta.0"
+
+  if OS.mac?
+    url "https://github.com/splunk/acs-cli/releases/download/v2.0.0-beta.0/acs_v2.0.0-beta.0_darwin_amd64.tar.gz"
+    sha256 "96f7ef7ddaff7a06b05298d71b384cfbfd1b5fe335511fa89dd48230a0a2ef6c"
+  elsif OS.linux?
+    url "https://github.com/splunk/acs-cli/releases/download/v2.0.0-beta.0/acs_v2.0.0-beta.0_linux_amd64.tar.gz"
+    sha256 "5c0c4cd4990e9381ab42cec26272eb27d48586841cb92aa07d1722b0a3610e78"
+  end
+
+  def install
+    bin.install "acs"
+  end
+
+  # Homebrew requires tests.
+  test do
+    system "#{bin}/acs version"
+  end
+end
+


### PR DESCRIPTION
Admin Config Service CLI is intended to provide our customers with an alternative handy command-line tool for self-service configuration via ACS APIs with minimum required user-inputs

v2.0.0-beta.0 is the first beta version of ACS CLI